### PR TITLE
Added feature of optional type casting.

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -45,7 +45,7 @@ validators.type = function validateType (instance, schema, options, ctx) {
   }
   var result = new ValidatorResult(instance, schema, options, ctx);
   var types = Array.isArray(schema.type) ? schema.type : [schema.type];
-  if (!types.some(this.testType.bind(this, instance, schema, options, ctx))) {
+  if (!types.some(this.testType.bind(this, instance, schema, result, options, ctx))) {
     var list = types.map(function (v) {
       return v.id && ('<' + v.id + '>') || (v+'');
     });
@@ -770,7 +770,7 @@ validators.not = validators.disallow = function validateNot (instance, schema, o
   if(!notTypes) return null;
   if(!Array.isArray(notTypes)) notTypes=[notTypes];
   notTypes.forEach(function (type) {
-    if (self.testType(instance, schema, options, ctx, type)) {
+    if (self.testType(instance, schema, result, options, ctx, type)) {
       var schemaId = type && type.id && ('<' + type.id + '>') || type;
       result.addError({
         name: 'not',

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -205,7 +205,7 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
   if(options.setDefaults && typeof instance === 'undefined' && schema.required !== true) {
       result.instance = instance = schema.default;
   }
-  
+
   var skipAttributes = options && options.skipAttributes || [];
   // Validate each schema attribute against the instance
   for (var key in schema) {
@@ -214,6 +214,9 @@ Validator.prototype.validateSchema = function validateSchema (instance, schema, 
       var validator = this.attributes[key];
       if (validator) {
         validatorErr = validator.call(this, instance, schema, options, ctx);
+        if (validatorErr && result.instance) {
+          result.instance = validatorErr.instance
+        }
       } else if (options.allowUnknownAttributes === false) {
         // This represents an error with the schema itself, not an invalid instance
         throw new SchemaError("Unsupported attribute: " + key, schema);
@@ -293,9 +296,9 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
  * @param type
  * @return {boolean}
  */
-Validator.prototype.testType = function validateType (instance, schema, options, ctx, type) {
+Validator.prototype.testType = function validateType (instance, schema, result, options, ctx, type) {
   if (typeof this.types[type] == 'function') {
-    return this.types[type].call(this, instance);
+    return this.types[type].call(this, instance, result, options);
   }
   if (type && typeof type == 'object') {
     var res = this.validateSchema(instance, type, options, ctx);
@@ -306,32 +309,51 @@ Validator.prototype.testType = function validateType (instance, schema, options,
 };
 
 var types = Validator.prototype.types = {};
-types.string = function testString (instance) {
+types.string = function testString (instance, result, options) {
+  // If the provided type is a number, cast it to string
+  if (typeof instance == 'number' && options.castTypes) {
+    result.instance = instance.toString();
+    return true;
+  }
   return typeof instance == 'string';
 };
-types.number = function testNumber (instance) {
+types.number = function testNumber (instance, result, options) {
   // isFinite returns false for NaN, Infinity, and -Infinity
+  // If the provided type is a string, cast it to a number
+  if (typeof instance == 'string' && options.castTypes) {
+    let num = parseFloat(instance)
+    if (isNaN(num)) return false;
+    result.instance = num;
+    return true;
+  }
   return typeof instance == 'number' && isFinite(instance);
 };
-types.integer = function testInteger (instance) {
+types.integer = function testInteger (instance, result, options) {
+  // If the provided type is a string, cast it to a number
+  if (typeof instance == 'string' && options.castTypes) {
+    let num = parseFloat(instance)
+    if (isNaN(num) || instance % 1 !== 0) return false;
+    result.instance = num;
+    return true;
+  }
   return (typeof instance == 'number') && instance % 1 === 0;
 };
-types.boolean = function testBoolean (instance) {
+types.boolean = function testBoolean (instance, result, options) {
   return typeof instance == 'boolean';
 };
-types.array = function testArray (instance) {
+types.array = function testArray (instance, result, options) {
   return instance instanceof Array;
 };
-types['null'] = function testNull (instance) {
+types['null'] = function testNull (instance, result, options) {
   return instance === null;
 };
-types.date = function testDate (instance) {
+types.date = function testDate (instance, result, options) {
   return instance instanceof Date;
 };
-types.any = function testAny (instance) {
+types.any = function testAny (instance, result, options) {
   return true;
 };
-types.object = function testObject (instance) {
+types.object = function testObject (instance, result, options) {
   // TODO: fix this - see #15
   return instance && (typeof instance) === 'object' && !(instance instanceof Array) && !(instance instanceof Date);
 };

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -12,6 +12,25 @@ describe('Attributes', function () {
       this.validator = new Validator();
     });
 
+    describe('string', function () {
+      it('should validate a valid string', function () {
+        this.validator.validate("foo", {'type': 'string'}).valid.should.be.true;
+      });
+
+      it('should not validate an invalid string', function () {
+        return this.validator.validate(0.25, { 'type': 'string' }).valid.should.be.false;
+      });
+
+      it('should validate an invalid string with casting enabled', function () {
+        return this.validator.validate(0.25, {'type': 'string'}, {castTypes: true}).valid.should.be.true;
+      });
+
+      it('should convert type of invalid string with casting enabled', function () {
+        return typeof (this.validator.validate(2, {'type': 'string'}, {castTypes: true}).instance) == 'number';
+      });
+
+    });
+
     describe('number', function () {
       it('should validate a valid number', function () {
         this.validator.validate(0, {'type': 'number'}).valid.should.be.true;
@@ -19,6 +38,14 @@ describe('Attributes', function () {
 
       it('should not validate an invalid number', function () {
         return this.validator.validate('0', {'type': 'number'}).valid.should.be.false;
+      });
+
+      it('should validate an invalid number with casting enabled', function () {
+        return this.validator.validate('0', {'type': 'number'}, {castTypes: true}).valid.should.be.true;
+      });
+
+       it('should convert type of invalid number with casting enabled', function () {
+        return typeof (this.validator.validate('0', {'type': 'integer'}, {castTypes: true}).instance) == 'number';
       });
 
       it('should not validate NaN', function () {
@@ -78,8 +105,20 @@ describe('Attributes', function () {
         return this.validator.validate(12, {'type': 'integer'}).valid.should.be.true;
       });
 
+      it('should validate invalid integer with casting enabled', function () {
+        return this.validator.validate("12", {'type': 'integer'}, {castTypes: true}).valid.should.be.true;
+      });
+
+      it('should convert type of invalid integer with casting enabled', function () {
+        return typeof (this.validator.validate("12", {'type': 'integer'}, {castTypes: true}).instance) == 'number';
+      });
+
       it('should not validate non integer', function () {
         return this.validator.validate(0.25, {'type': 'integer'}).valid.should.be.false;
+      });
+
+      it('should not validate non integer with casting enabled', function () {
+        return this.validator.validate("0.25", {'type': 'integer'}, {castTypes: true}).valid.should.be.false;
       });
 
       it('should not validate an undefined instance', function () {
@@ -295,27 +334,27 @@ describe('Attributes', function () {
       return this.validator.validate({'the_field':'bar'}, {'type': 'object', 'properties':{'the_field': {'enum': ['foo', 'bar', 'baz'], 'required': true}}}).valid.should.be.true;
     });
   });
-  
+
   describe('default', function () {
     beforeEach(function () {
       this.validator = new Validator();
     });
-    
+
     it('should preserve value if field is defined', function () {
       var validation = this.validator.validate({'the_field': 'foo'}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}}, {setDefaults: true});
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.the_field.should.equal('foo');
     });
-    
+
     it('should not set default value even field is undefined if options.setDefaults is not true', function () {
       var validation = this.validator.validate({}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}});
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.should.not.have.property('the_field');
     });
-    
+
     it('should set default value if field is undefined and options.setDefaults is true', function () {
       var validation = this.validator.validate({}, {'type': 'object', 'properties':{'the_field':{'type': 'string', 'default': 'bar'}}}, {setDefaults: true})
-      validation.valid.should.be.true; 
+      validation.valid.should.be.true;
       validation.instance.the_field.should.equal('bar');
     });
   });


### PR DESCRIPTION
- The standard behavior is not changed
- Use option: {castType: true} to enable the feature
- If possible wrongly provided types will be casted into the desired type
- The converted types will be made part of the validation result set
- Added several tests testing and demonstrating the new feature